### PR TITLE
feat: completed adding link to invoice show page

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -49,8 +49,8 @@ class Item < ApplicationRecord
     .sum('(invoice_items.unit_price * invoice_items.quantity)')
   end
 
-  # def self.discount_revenue
-  #   require "pry"; binding.pry
-  # end
+  def find_discount
+    discounts.joins(merchant:[:invoice_items]).where('discounts.threshold <= invoice_items.quantity').where(invoice_items: {item_id: self.id}).order(discount: :desc).limit(1).first
+  end
 
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -17,7 +17,13 @@
     <p>Item Name: <%= item.name %></p>
     <p>Item Price: <%= item.unit_price %></p>
     <p>Item Quantity: <%= item.quantity_purchased(@invoice.id) %></p>
-    <p>Item Shipping Status: <%= item.shipping_status(@invoice.id) %>  </p>
+    <p>Item Shipping Status: <%= item.shipping_status(@invoice.id) %>  
+      <p id="item-<%= item.id %>-discount">
+      <% if item.find_discount != nil %>
+        <%= link_to "View Discount Info", merchant_discount_path(@merchant, item.find_discount) %>
+      <% end %>
+      </p>
+    </p>
     <%= form_with model: [@merchant, @invoice], local: true do |form| %>
       <%= form.label :item_id %>
       <%= form.hidden_field :item_id, value: "#{item.id}" %>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -270,7 +270,18 @@ RSpec.describe 'Merchant Invoice Show Page' do
       within("#invoice-revenue") do
         expect(page).to have_content(@invoice_2.discounted_revenue_of_invoice)
       end
+    end
 
+    it 'Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)' do
+      visit merchant_invoice_path(@merchant_1, @invoice_1)
+
+      within("#invoice-items-info") do
+        within("#item-#{@item_5.id}-discount") do
+          click_link'View Discount Info'
+        end
+      end
+
+      expect(current_path).to eq(merchant_discount_path(@merchant_1, @discount_2))
     end
 
   end

--- a/spec/models/discount_spec.rb
+++ b/spec/models/discount_spec.rb
@@ -8,4 +8,4 @@ RSpec.describe Discount, type: :model do
   describe 'relationships' do
     it { should belong_to(:merchant) }
   end
-end
+endex

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -76,13 +76,20 @@ RSpec.describe Item, type: :model do
 
   describe 'instance methods' do
     before :each do
-      @item_1 = create(:item)
-      @item_2 = create(:item)
+      @merchant_1 = create(:merchant)
+      
+      @item_1 = create(:item, name: "item_1", merchant: @merchant_1)
+      @item_2 = create(:item, name: "item_2", merchant: @merchant_1)
+      @item_3 = create(:item, name: "item_3", merchant: @merchant_1)
 
       @invoice_1 = create(:invoice)
 
-      @invoice_item_1 = create(:invoice_items, invoice_id: @invoice_1.id, item_id: @item_1.id)
-      @invoice_item_2 = create(:invoice_items, invoice_id: @invoice_1.id, item_id: @item_2.id)
+      @invoice_item_1 = create(:invoice_items, invoice: @invoice_1, item: @item_1, unit_price: 1000, quantity: 10)
+      @invoice_item_2 = create(:invoice_items, invoice: @invoice_1, item: @item_2, unit_price: 700, quantity: 7)
+      @invoice_item_3 = create(:invoice_items, invoice: @invoice_1, item: @item_3, unit_price: 700, quantity: 5)
+
+      @discount_1 = create(:discount, discount: 0.25, threshold: 7, merchant: @merchant_1)
+      @discount_2 = create(:discount, discount: 0.5, threshold: 8, merchant: @merchant_1)
     end
 
     it "#quantity_purchased" do
@@ -102,6 +109,12 @@ RSpec.describe Item, type: :model do
 
     it "#item-revenue" do
       expect(@item_10.revenue).to eq(50000)
+    end
+
+    it "#find_discount" do
+      expect(@item_1.find_discount).to eq(@discount_2)
+      expect(@item_2.find_discount).to eq(@discount_1)
+      expect(@item_3.find_discount).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
As a merchant
When I visit my merchant invoice show page
Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)

And adds an item method to find the discount associated with that item.