### PR TITLE
9 upcoming holidays

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
-  
+  before_action :holidays
+
+  def holidays
+    @holidays = HolidaySearch.holidays
+  end
 end

--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -1,0 +1,8 @@
+class Holiday
+  attr_reader :date, :name
+
+  def initialize(repo_data)
+    @date = repo_data[:date]
+    @name = repo_data[:name]
+  end
+end

--- a/app/search/holiday_search.rb
+++ b/app/search/holiday_search.rb
@@ -1,0 +1,7 @@
+class HolidaySearch
+  def self.holidays 
+    repo_data ||= HolidayService.get_holidays
+    repo_data[0..2].map do |holiday|
+      Holiday.new(holiday)
+    end
+  end

--- a/app/search/holiday_search.rb
+++ b/app/search/holiday_search.rb
@@ -5,3 +5,4 @@ class HolidaySearch
       Holiday.new(holiday)
     end
   end
+end

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -4,12 +4,12 @@ require 'json'
 class HolidayService
 
   def self.get_holidays
-    return [{date: '12/25/2022', name: "Christmas Day - TEST"}, {date: '01/01/2023', name: "New Year's Day - TEST"}, {date: '02/14/2023', name: "Valentine's Day - TEST"}] if Rails.env == 'test'
+    # return [{date: '12/25/2022', name: "Christmas Day - TEST"}, {date: '01/01/2023', name: "New Year's Day - TEST"}, {date: '02/14/2023', name: "Valentine's Day - TEST"}] if Rails.env == 'test'
     get_uri('https://date.nager.at/api/v3/NextPublicHolidays/US')
   end
 
   def self.get_uri(uri)
-    data = HTTParty.get(uri, headers: true)
+    data = HTTParty.get(uri)
     parsed = JSON.parse(data.body, symbolize_names: true)
   end
 end

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -1,0 +1,15 @@
+require 'httparty'
+require 'json'
+
+class HolidayService
+
+  def self.get_holidays
+    return [{date: '12/25/2022', name: "Christmas Day - TEST"}, {date: '01/01/2023', name: "New Year's Day - TEST"}, {date: '02/14/2023', name: "Valentine's Day - TEST"}] if Rails.env == 'test'
+    get_uri('https://date.nager.at/api/v3/NextPublicHolidays/US')
+  end
+
+  def self.get_uri(uri)
+    data = HTTParty.get(uri, headers: true)
+    parsed = JSON.parse(data.body, symbolize_names: true)
+  end
+end

--- a/app/views/discounts/index.html.erb
+++ b/app/views/discounts/index.html.erb
@@ -3,8 +3,8 @@
 <div id="upcoming-holidays">
   <h2>Upcoming Holidays:</h2>
     <ol>  
-      <% HolidaySearch.holidays.each do |holiday| %>
-        <li><%= holiday.name %> is coming up on <%= holiday.date %></li>
+      <% @holidays.each do |holiday| %>
+        <li><%= holiday.name %> is on <%= holiday.date %></li>
       <% end %>
     </ol>
 </div>

--- a/app/views/discounts/index.html.erb
+++ b/app/views/discounts/index.html.erb
@@ -1,5 +1,14 @@
 <h1>Bulk Discounts for <%= @merchant.name %></h1>
 
+<div id="upcoming-holidays">
+  <h2>Upcoming Holidays:</h2>
+    <ol>  
+      <% HolidaySearch.holidays.each do |holiday| %>
+        <li><%= holiday.name %> is coming up on <%= holiday.date %></li>
+      <% end %>
+    </ol>
+</div>
+
 <div>
   <%= button_to "Add New Bulk Discount", new_merchant_discount_path(@merchant), method: :get%>
 </div>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -119,8 +119,7 @@ RSpec.describe "Admin Invoice Show Page" do
 
           it 'I see the total revenue for my merchant from this invoice (not including discounts)' do
             visit admin_invoice_path(@invoice_1)
-            save_and_open_page
-
+            
             within("#invoice-details-#{@invoice_1.id}") do
               within("#invoice-revenue") do
                 expect(page).to have_content((@invoice_1.total_revenue_of_invoice/100.00).to_s(:delimited))

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Merchant Bulk Discounts Index' do
     describe 'I am taken to my bulk discounts index page' do
       it 'I see all of my bulk discounts including their percentage discount and quantity thresholds' do
         visit merchant_discounts_path(@merchant_1)
+        save_and_open_page
         
         within("#merchant-#{@merchant_1.id}-discounts") do
           within("#discount-#{@discount_1.id}") do

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe 'Merchant Bulk Discounts Index' do
     describe 'I am taken to my bulk discounts index page' do
       it 'I see all of my bulk discounts including their percentage discount and quantity thresholds' do
         visit merchant_discounts_path(@merchant_1)
-        save_and_open_page
         
         within("#merchant-#{@merchant_1.id}-discounts") do
           within("#discount-#{@discount_1.id}") do

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe 'Merchant Invoice Show Page' do
 
     it 'I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation' do
       visit merchant_invoice_path(@merchant_1, @invoice_1)
-      save_and_open_page
+      
       within("#invoice-revenue") do
         expect(page).to have_content((@invoice_1.discounted_revenue_of_invoice/100.00).to_s(:delimited))
       end

--- a/spec/poros/holiday_spec.rb
+++ b/spec/poros/holiday_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe Holiday do
     holiday = Holiday.new(date: "12/25/2022", name: "Christmas Day")
     expect(holiday).to be_instance_of(Holiday)
     expect(holiday.date).to eq("12/25/2022")
-    expect(holiday.name).to eq("Chistmas Day")
+    expect(holiday.name).to eq("Christmas Day")
   end
 end

--- a/spec/poros/holiday_spec.rb
+++ b/spec/poros/holiday_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Holiday do
+  it 'does exist' do
+    holiday = Holiday.new(date: "12/25/2022", name: "Christmas Day")
+    expect(holiday).to be_instance_of(Holiday)
+    expect(holiday.date).to eq("12/25/2022")
+    expect(holiday.name).to eq("Chistmas Day")
+  end
+end

--- a/spec/services/holiday_service_spec.rb
+++ b/spec/services/holiday_service_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe HolidayService do
+  it 'gets the dates of the next 3 holidays' do
+    allow(HolidayService).to receive(:get_holidays).and_return([{date: "01/01/2023"}])
+    repos = HolidayService.get_holidays
+    expect(repos).to be_an(Array)
+    expect(repos[0]).to be_an(Hash)
+    expect(repos[0]).to have_key(:date)
+  end
+  
+  it 'gets the name of teh next 3 holidays' do
+    allow(HolidayService).to receive(:get_holidays).and_return([{name: "New Year's Day"}])
+    repos = HolidayService.get_holidays
+    expect(repos).to be_an(Array)
+    expect(repos[0]).to be_an(Hash)
+    expect(repos[0]).to have_key(:name)
+  end
+end


### PR DESCRIPTION
As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section, the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)